### PR TITLE
Add eSIM management

### DIFF
--- a/lib/satellite/src/modem_manager.cpp
+++ b/lib/satellite/src/modem_manager.cpp
@@ -85,6 +85,8 @@ namespace {
 
 const int PROFILES_SIZE_MAX = 4096;
 char profiles[PROFILES_SIZE_MAX] = {0};
+const int CSIM_RESPONSE_SIZE_MAX = 4096;
+char csimResponse[CSIM_RESPONSE_SIZE_MAX] = {0};
 
 } // namespace annonymous
 
@@ -325,7 +327,7 @@ int ModemManager::enableDisableProfile(int type, char* specifiedIccid, int radio
     char iccidList[ICCID_RESULTS_MAX][ICCID_LEN + 1];
     if (profileSize > 0) {
         char requestData[32] = {0};
-        char csimResponse[4096] = {0};
+        memset(&csimResponse, 0, sizeof(csimResponse));
         sprintf(requestData, "AT+CSIM=10,\"81C00000%02X\"", profileSize);
         Cellular.command(cbCSIMstring, csimResponse, requestData); // returns +CSIM: 160,"BF2D4BA049E32D5A0A980010325476981032149F700100921B47534D412054532E343820584F5220546573742050726F66696C65E3185A0A988803070000156406669F70010192065477696C696F9000"
 
@@ -421,7 +423,7 @@ int ModemManager::esimProfiles(char* specifiedIccid, char* profilesBuffer, int p
     char iccidList[ICCID_RESULTS_MAX][ICCID_LEN + 1];
     if (profileSize > 0) {
         char requestData[32] = {0};
-        char csimResponse[4096] = {0};
+        memset(&csimResponse, 0, sizeof(csimResponse));
         sprintf(requestData, "AT+CSIM=10,\"81C00000%02X\"", profileSize);
         Cellular.command(cbCSIMstring, csimResponse, requestData); // returns +CSIM: 160,"BF2D4BA049E32D5A0A980010325476981032149F700100921B47534D412054532E343820584F5220546573742050726F66696C65E3185A0A988803070000156406669F70010192065477696C696F9000"
         LOG_PRINTF_C(TRACE, "app", "%010lu [%s] D[%d]: ", millis(), "app", strlen(csimResponse));

--- a/lib/satellite/src/modem_manager.cpp
+++ b/lib/satellite/src/modem_manager.cpp
@@ -1,0 +1,599 @@
+/*
+ * Copyright (c) 2024 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "modem_manager.h"
+
+#include "logging.h"
+LOG_SOURCE_CATEGORY("ncp.esim");
+
+#include "check.h"
+#include "scope_guard.h"
+#include "stream_util.h"
+#include "hex_to_bytes.h"
+
+#include <str_util.h>
+
+#include <memory>
+#include <cstdint>
+#include <pb_encode.h>
+#include <cloud/cloud_new.pb.h>
+
+/*
+// List of all defined system errors
+    NONE                        0
+    UNKNOWN                  -100
+    BUSY                     -110
+    NOT_SUPPORTED            -120
+    NOT_ALLOWED              -130
+    CANCELLED                -140
+    ABORTED                  -150
+    TIMEOUT                  -160
+    NOT_FOUND                -170
+    ALREADY_EXISTS           -180
+    TOO_LARGE                -190
+    NOT_ENOUGH_DATA          -191
+    LIMIT_EXCEEDED           -200
+    END_OF_STREAM            -201
+    INVALID_STATE            -210
+    FLASH_IO                 -219
+    IO                       -220
+    WOULD_BLOCK              -221
+    FILE                     -225
+    PATH_TOO_LONG            -226
+    NETWORK                  -230
+    PROTOCOL                 -240
+    INTERNAL                 -250
+    NO_MEMORY                -260
+    INVALID_ARGUMENT         -270
+    BAD_DATA                 -280
+    OUT_OF_RANGE             -290
+    DEPRECATED               -300
+    ...
+    AT_NOT_OK               -1200
+    AT_RESPONSE_UNEXPECTED  -1210
+    ...
+*/
+
+namespace particle {
+
+namespace {
+
+#define ICCID_KIGEN_DEFAULT     "89000123456789012358"
+#define ICCID_KIGEN_TEST        "89000123456789012341"
+#define ICCID_TWILIO_PREFIX     "8988"
+#define ICCID_SKYLO_PREFIX      "8990"
+#define ICCID_PREFIX_LEN        (4)
+#define ICCID_RESULTS_MAX       (8)
+#define ICCID_MARKER            "5A0A"
+#define ICCID_MARKER_LEN        (4)
+#define ICCID_DISABLE           (0)
+#define ICCID_ENABLE            (1)
+
+const int PROFILES_SIZE_MAX = 4096;
+char profiles[PROFILES_SIZE_MAX] = {0};
+
+} // namespace annonymous
+
+ModemManager::ModemManager() : begun_(false)
+{
+
+}
+
+ModemManager::~ModemManager() {
+    if (begun_) {
+        // de-init stuff
+    }
+}
+
+int ModemManager::cbCFUN(int type, const char* buf, int len, int* cfun)
+{
+    if ((type == TYPE_PLUS) && cfun) {
+        if (sscanf(buf, "\r\n+CFUN: %d", cfun) == 1)
+            /*nothing*/;
+    }
+    return WAIT;
+}
+
+int ModemManager::cbIOTOPMODE(int type, const char* buf, int len, int* mode)
+{
+    if ((type == TYPE_PLUS) && mode) {
+        if (sscanf(buf, "\r\n+QCFG=\"iotopmode\",%d", mode) == 1)
+            /*nothing*/;
+    }
+    return WAIT;
+}
+
+int ModemManager::cbCSIMint(int type, const char* buf, int len, int* csimInt)
+{
+    if ((type == TYPE_PLUS) && csimInt) {
+        if (sscanf(buf, "\r\n+CSIM: 4,\"61%2x", csimInt) == 1)
+            /*nothing*/;
+    }
+    return WAIT;
+}
+
+int ModemManager::cbCSIMstring(int type, const char* buf, int len, char* csimString)
+{
+    if ((type == TYPE_PLUS) && csimString) {
+        if (sscanf(buf, "\r\n+CSIM: %*d,\"%[^\"]\r\n", csimString) == 1)
+            /*nothing*/;
+    }
+    return WAIT;
+}
+
+int ModemManager::cbICCID(int type, const char* buf, int len, char* iccid)
+{
+    if ((type == TYPE_PLUS) && iccid) {
+        if (sscanf(buf, "\r\n+QCCID: %[^\r]\r\n", iccid) == 1)
+            /*nothing*/;
+    }
+    return WAIT;
+}
+
+void ModemManager::swapNibbles(const char* input, char* output) {
+    for (int i = 0; i < ICCID_LEN; i+=2) {
+        output[i] = input[i+1];
+        output[i+1] = input[i];
+    }
+    output[ICCID_LEN] = 0;
+}
+
+int ModemManager::isValidHexString(const char *str, int length) {
+    for (int i = 0; i < length; i++) {
+        if (!isxdigit(str[i])) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+void ModemManager::stripTrailingF(char* iccid) {
+    // Strip trailing F on 19 digit ICCID's
+    if (strlen(iccid) == ICCID_LEN && (iccid[strlen(iccid) - 1] == 'f' || iccid[strlen(iccid) - 1] == 'F')) {
+        iccid[strlen(iccid) - 1] = 0;
+    }
+}
+
+int ModemManager::findIccids(const char *input, char results[][ICCID_LEN + 1], bool includeTestProfile) {
+    int count = 0;
+    const char *pos = input;
+
+    while ((pos = strstr(pos, ICCID_MARKER)) != NULL) {
+        pos += ICCID_MARKER_LEN;
+
+        if (strlen(pos) >= ICCID_LEN && isValidHexString(pos, ICCID_LEN) == 0) {
+            swapNibbles(pos, results[count]); // swap into results
+            stripTrailingF(results[count]);
+            if (!includeTestProfile && strncmp(results[count], ICCID_KIGEN_TEST, ICCID_LEN) == 0) {
+                results[count][0] = 0; // remove
+            } else {
+                results[count][ICCID_LEN] = 0;
+                count++;
+            }
+
+            if (count >= ICCID_RESULTS_MAX) {
+                break;
+            }
+        }
+
+        pos += ICCID_LEN;
+    }
+
+    return count;
+}
+
+int ModemManager::getICCID(char* i, bool log) {
+    char iccid[30] = {0};
+
+    int ret = Cellular.command(cbICCID, iccid, 10000, "AT+QCCID\r\n");
+    if ((ret == RESP_OK) && (strcmp(iccid, "") != 0)) {
+        // Log.info("SIM ICCID = %s", iccid);
+    } else {
+        Log.info("SIM ICCID NOT FOUND!");
+        return -1;
+    }
+
+    stripTrailingF(iccid);
+    if (ret != RESP_OK) {
+        strcpy(iccid, "");
+        Log.error("getICCID: %d", ret);
+        return -2;
+    } else {
+        if (log) {
+            Log.info("ICCID currently active: %s ", iccid);
+            if (strcmp(iccid, ICCID_KIGEN_DEFAULT) == 0) {
+                LOG_PRINTF(TRACE, "(Kigen Default Profile)\n");
+            } else if (strcmp(iccid, ICCID_KIGEN_TEST) == 0) {
+                LOG_PRINTF(TRACE, "(Kigen Test Profile)\n");
+            } else if (strncmp(iccid, ICCID_TWILIO_PREFIX, ICCID_PREFIX_LEN) == 0) {
+                LOG_PRINTF(TRACE, "(Twilio Super SIM)\n");
+            } else if (strncmp(iccid, ICCID_SKYLO_PREFIX, ICCID_PREFIX_LEN) == 0) {
+                LOG_PRINTF(TRACE, "(Skylo SIM)\n");
+            } else {
+                LOG_PRINTF(TRACE, "(Unknown)\n");
+            }
+        }
+    }
+
+    updateCachedRadioType(iccid);
+
+    strcpy(i, iccid);
+    return 0;
+}
+
+void ModemManager::enableDisableICCID(int type, char* specifiedIccid, int radioType) {
+    if (strlen(specifiedIccid) < (ICCID_LEN-1)) {
+        return;
+    }
+
+    // Add F to the end of 19 digit ICCIDs for CSIM commands
+    if (strlen(specifiedIccid) == (ICCID_LEN-1)) {
+        specifiedIccid[ICCID_LEN-1] = 'F';
+        specifiedIccid[ICCID_LEN] = 0;
+    }
+
+    char iccidNibbleSwapped[ICCID_LEN + 1] = {0};
+    swapNibbles(specifiedIccid, iccidNibbleSwapped);
+    if (RESP_OK != Cellular.command(10000, "AT+CSIM=10,\"0070000000\"\r\n")) {
+        delay(1000);
+        Cellular.command(10000, "AT+CSIM=10,\"0070000000\"");
+    }
+    if (RESP_OK != Cellular.command(10000, "AT+CSIM=42,\"01A4040410A0000005591010FFFFFFFF8900000100\"\r\n")) {
+        delay(1000);
+        Cellular.command(10000, "AT+CSIM=42,\"01A4040410A0000005591010FFFFFFFF8900000100\"\r\n");
+    }
+    // Insert the desired nibble swapped profile here
+    // AT+CSIM=50,"81E2910014BF3211A00F5A0Axxxxxxxxxxxxxxxxxxxx810101"
+    char requestData[70] = {0};
+    if (type == 0) {
+        // Disable
+        sprintf(requestData, "AT+CSIM=50,\"81E2910014BF3211A00F5A0A%s810101\"\r\n", iccidNibbleSwapped);
+    } else {
+        // Enable
+        sprintf(requestData, "AT+CSIM=50,\"81E2910014BF3111A00F5A0A%s810101\"\r\n", iccidNibbleSwapped);
+    }
+    if (RESP_OK != Cellular.command(10000, requestData)) {
+        delay(1000);
+        Cellular.command(10000, requestData);
+    }
+    delay(1000); // wait a bit before closing the channel
+    if (RESP_OK != Cellular.command(10000, "AT+CSIM=10,\"81C0000006\"\r\n")) {
+        delay(1000);
+        Cellular.command(10000, "AT+CSIM=10,\"81C0000006\"\r\n");
+    }
+    if (RESP_OK != Cellular.command(10000, "AT+CSIM=10,\"0070800100\"\r\n")) {
+        delay(1000);
+        Cellular.command(10000, "AT+CSIM=10,\"0070800100\"\r\n");
+    }
+
+    // Toggle CFUN to refresh SIM data
+    Log.info("Toggling modem power to refresh SIM info...");
+    Cellular.command(180000, "AT+CFUN=0\r\n");
+    waitAtResponse(10);
+    // If RADIO_UNKNOWN specified, nothing will be set.
+    if (radioType != RADIO_UNKNOWN) {
+        Cellular.command(2000, "AT+QCFG=\"iotopmode\",%d,1\r\n", radioType == RADIO_CELLULAR ? 0 : 3);
+    }
+    Cellular.command(180000, "AT+CFUN=1\r\n");
+    waitAtResponse(10);
+}
+
+int ModemManager::enableDisableProfile(int type, char* specifiedIccid, int radioType) {
+    char iccid[30] = {0};
+
+    stripTrailingF(specifiedIccid);
+
+    if (strcmp(specifiedIccid, ICCID_KIGEN_DEFAULT) == 0) {
+        Log.error("This is the Kigen Default ICCID. Invalid argument.");
+        return ENABLE_DISABLE_ICCID_IS_DEFAULT;
+    }
+
+    int cfunVal = -1;
+    Cellular.command(cbCFUN, &cfunVal, 10000, "AT+CFUN?\r\n");
+    if (cfunVal != 1) {
+        Cellular.command(10000, "AT+CFUN=1");
+        delay(5000);
+    }
+
+    int iotopmodeVal = -1;
+    Cellular.command(cbIOTOPMODE, &iotopmodeVal, 10000, "AT+QCFG=\"iotopmode\"\r\n");
+    if ((radioType == RADIO_CELLULAR && iotopmodeVal == 0) ||
+            (radioType == RADIO_SATELLITE && iotopmodeVal == 3)) {
+        // If already set correctly, prevent IOTOPMODE from being set later on
+        radioType = RADIO_UNKNOWN;
+    }
+
+    // QUERY ALL PROFILES
+    Cellular.command(10000, "AT+CSIM=42,\"01A4040410A0000005591010FFFFFFFF8900000100\"\r\n");  // returns +CSIM: 4,"6121"
+    int profileSize = 0;
+    Cellular.command(cbCSIMint, &profileSize, 10000, "AT+CSIM=28,\"81E2910009BF2D065C045A9F7092\"\r\n"); // returns +CSIM: 4,"614E"
+    int iccidsFound = 0;
+    char iccidList[ICCID_RESULTS_MAX][ICCID_LEN + 1];
+    if (profileSize > 0) {
+        char requestData[32] = {0};
+        char csimResponse[4096] = {0};
+        sprintf(requestData, "AT+CSIM=10,\"81C00000%02X\"", profileSize);
+        Cellular.command(cbCSIMstring, csimResponse, requestData); // returns +CSIM: 160,"BF2D4BA049E32D5A0A980010325476981032149F700100921B47534D412054532E343820584F5220546573742050726F66696C65E3185A0A988803070000156406669F70010192065477696C696F9000"
+
+        if (strlen(csimResponse) > 0) {
+            // Test with 3 profiles (TEST, SKYLO, TWILIO) !!!! DO NOT TRY TO SET THIS DATA !!!!
+            // iccidsFound = findIccids("+CSIM: 238,\"BF2D72A070E32D5A0A980010325476981032149F700100921B47534D412054532E343820584F5220546573742050726F66696C65E3255A0A980991080120002004309F7001009213536B796C6F202D204F7065726174696F6E616CE3185A0A988803070000155488619F70010192065477696C696F9000\"", iccidList, false /*includeTestProfile*/);
+            iccidsFound = findIccids(csimResponse, iccidList, true /*includeTestProfile*/);
+            if (iccidsFound == 0) {
+                Log.error("No ICCID's found");
+                return ENABLE_DISABLE_ICCID_DOES_NOT_EXIST;
+            }
+            // for (int i = 0; i < iccidsFound; i++) {
+            //     Log.info("ICCID%d: %s\n", i+1, iccidList[i]);
+            // }
+            int iccidMatched = 0;
+            for (int i = 0; i < iccidsFound; i++) {
+                // Log.info("ICCID%d: %s\n", i+1, iccidList[i]);
+                if (strcmp(iccidList[i], specifiedIccid) == 0) {
+                    iccidMatched = 1;
+                    break;
+                }
+            }
+            if (!iccidMatched) {
+                Log.error("Invalid ICCID!");
+                return ENABLE_DISABLE_ICCID_DOES_NOT_EXIST;
+            }
+        }
+    }
+
+    getICCID(iccid, /* log results */ false);
+
+    int ret = ENABLE_DISABLE_SUCCESS;
+    Log.info("ICCID currently active: %s", iccid);
+    if (type == ICCID_DISABLE && strncmp(iccid, specifiedIccid, 20) != 0) {
+        Log.info("Profile not active!");
+        ret = ENABLE_DISABLE_ICCID_NOT_ACTIVE;
+    } else if (type == ICCID_ENABLE) {
+        if (strncmp(iccid, specifiedIccid, 20) == 0) {
+            Log.info("Profile already active!");
+            ret = ENABLE_DISABLE_ICCID_IS_ACTIVE;
+        } else if (strncmp(iccid, ICCID_KIGEN_DEFAULT, 20) != 0) {
+            // disable currently active ICCID that is not the Kigen Default
+            Log.info("Disabling currently active: %s", iccid);
+            enableDisableICCID(ICCID_DISABLE, iccid, RADIO_UNKNOWN);
+        }
+    }
+
+    if (ret != ENABLE_DISABLE_SUCCESS) {
+        // we have an error, but need to set iotopmode before exiting
+        if (radioType != RADIO_UNKNOWN) {
+            Cellular.command(180000, "AT+CFUN=0\r\n");
+            waitAtResponse(10);
+            Cellular.command(2000, "AT+QCFG=\"iotopmode\",%d,1\r\n", radioType == RADIO_CELLULAR ? 0 : 3);
+            Cellular.command(180000, "AT+CFUN=1\r\n");
+            waitAtResponse(10);
+        }
+
+        return ret;
+    }
+
+    Log.info("%sabling profile %s\n", type ? "En" : "Dis", specifiedIccid);
+    enableDisableICCID(type, specifiedIccid, radioType);
+
+    getICCID(iccid, /* log results */ true);
+
+    return ENABLE_DISABLE_SUCCESS;
+}
+
+int ModemManager::esimProfiles(char* specifiedIccid, char* profilesBuffer, int profilesBufferLen) {
+    char iccid[30] = {0};
+    int matched = 0;
+    int silent = 0;
+    if (specifiedIccid && strlen(specifiedIccid) > 0) {
+        silent = 1;
+        stripTrailingF(specifiedIccid);
+    }
+
+    int cfunVal = -1;
+    Cellular.command(cbCFUN, &cfunVal, 10000, "AT+CFUN?\r\n");
+    if (cfunVal != 1) {
+        Cellular.command(10000, "AT+CFUN=1");
+        delay(5000);
+    }
+
+    // Query SIM card Currently Active ICCID
+    getICCID(iccid, /* log results */ false);
+
+    // QUERY ALL PROFILES
+    Cellular.command(10000, "AT+CSIM=42,\"01A4040410A0000005591010FFFFFFFF8900000100\"\r\n");  // returns +CSIM: 4,"6121"
+    int profileSize = 0;
+    Cellular.command(cbCSIMint, &profileSize, 10000, "AT+CSIM=28,\"81E2910009BF2D065C045A9F7092\"\r\n"); // returns +CSIM: 4,"614E"
+    int iccidsFound = 0;
+    char iccidList[ICCID_RESULTS_MAX][ICCID_LEN + 1];
+    if (profileSize > 0) {
+        char requestData[32] = {0};
+        char csimResponse[4096] = {0};
+        sprintf(requestData, "AT+CSIM=10,\"81C00000%02X\"", profileSize);
+        Cellular.command(cbCSIMstring, csimResponse, requestData); // returns +CSIM: 160,"BF2D4BA049E32D5A0A980010325476981032149F700100921B47534D412054532E343820584F5220546573742050726F66696C65E3185A0A988803070000156406669F70010192065477696C696F9000"
+        LOG_PRINTF_C(TRACE, "app", "%010lu [%s] D[%d]: ", millis(), "app", strlen(csimResponse));
+        LOG_WRITE_C(TRACE, "app", csimResponse, strlen(csimResponse));
+        LOG_PRINTF(TRACE, "\r\n");
+
+        if (strlen(csimResponse) > 0) {
+            // Test with 3 profiles (TEST, SKYLO, TWILIO) !!!! DO NOT TRY TO SET THIS DATA !!!!
+            // iccidsFound = findIccids("+CSIM: 238,\"BF2D72A070E32D5A0A980010325476981032149F700100921B47534D412054532E343820584F5220546573742050726F66696C65E3255A0A980991080120002004309F7001009213536B796C6F202D204F7065726174696F6E616CE3185A0A988803070000155488619F70010192065477696C696F9000\"", iccidList, true /*includeTestProfile*/);
+            iccidsFound = findIccids(csimResponse, iccidList, true /*includeTestProfile*/);
+            // Log.info("iccidsFound: %d", iccidsFound);
+            char temp_profiles[512] = {0};
+            // if (!silent) {
+            //     Log.info("\n");
+            // }
+            for (int i = 0; i < iccidsFound; i++) {
+                char temp[40] = {0};
+                sprintf(temp, "[%s, %s]", iccidList[i], strcmp(iccid, iccidList[i])==0 ? "enabled" : "disabled");
+                if (!silent) {
+                    // printf("%s", temp);
+                    strcat(temp_profiles, temp);
+                }
+                // if (strcmp(iccidList[i], ICCID_KIGEN_TEST) == 0) {
+                //     printf(" (Kigen Test Profile)");
+                // }
+                if (i+1 != iccidsFound) {
+                    if (!silent) {
+                        // printf("\n");
+                        strcat(temp_profiles, "\n");
+                    }
+                }
+                if (silent) {
+                    if (strcmp(specifiedIccid, iccidList[i]) == 0) {
+                        matched = 1; // found
+                        if (strcmp(iccid, iccidList[i])==0) {
+                            matched = 2; // enabled
+                        }
+                    }
+                }
+            }
+            if (!silent) {
+                Log.info("\n%s", temp_profiles);
+                if (profilesBuffer && ((int)strlen(temp_profiles) < profilesBufferLen)) {
+                    strncpy(profilesBuffer, temp_profiles, profilesBufferLen);
+                }
+            }
+        } else {
+            Log.info("[]");
+        }
+    } else {
+        Log.info("[]");
+    }
+
+    return matched;
+}
+
+int ModemManager::esimEnable(char* specifiedIccid) {
+    return enableDisableProfile(ICCID_ENABLE, specifiedIccid, RADIO_UNKNOWN);
+}
+
+int ModemManager::esimDisable(char* specifiedIccid) {
+    return enableDisableProfile(ICCID_DISABLE, specifiedIccid, RADIO_UNKNOWN);
+}
+
+int ModemManager::findIccidByType(const char* inputBuffer, int inputBufferLen, char* matchedIccid, int radioType) {
+    const char* p = inputBuffer;
+
+    while ((p = strchr(p, '[')) != NULL) {
+        p++;
+        const char* end = strchr(p, ',');
+        if (!end || (end - p) < ICCID_PREFIX_LEN) {
+            p++;
+            continue;
+        }
+
+        if ((radioType == RADIO_CELLULAR && strncmp(p, ICCID_TWILIO_PREFIX, ICCID_PREFIX_LEN) == 0) ||
+                (radioType == RADIO_SATELLITE && strncmp(p, ICCID_SKYLO_PREFIX, ICCID_PREFIX_LEN) == 0))
+        {
+            int len = end - p;
+            if (len >= inputBufferLen) {
+                len = inputBufferLen - 1;
+            }
+            strncpy(matchedIccid, p, len);
+            matchedIccid[len] = 0;
+
+            return 0;
+        }
+
+        p = end;
+    }
+
+    return -1;
+}
+
+void ModemManager::updateCachedRadioType(char* iccid) {
+    if (strncmp(iccid, ICCID_TWILIO_PREFIX, ICCID_PREFIX_LEN) == 0) {
+        cachedRadioType_ = RADIO_CELLULAR;
+    } else if (strncmp(iccid, ICCID_SKYLO_PREFIX, ICCID_PREFIX_LEN) == 0) {
+        cachedRadioType_ = RADIO_SATELLITE;
+    } else {
+        cachedRadioType_ = RADIO_UNKNOWN;
+    }
+}
+
+radio_type_t ModemManager::radioEnabled() {
+    if (cachedRadioType_ == RADIO_UNKNOWN) {
+        char iccid[ICCID_LEN + 1] = {0};
+        getICCID(iccid, /* log results */ false);
+    }
+
+    // switch (cachedRadioType_) {
+    //     case RADIO_UNKNOWN: Log.info("RADIO_UNKNOWN"); break;
+    //     case RADIO_CELLULAR: Log.info("RADIO_CELLULAR"); break;
+    //     case RADIO_SATELLITE: Log.info("RADIO_SATELLITE"); break;
+    // };
+    // delay(1000);
+
+    return cachedRadioType_;
+}
+
+int ModemManager::radioEnable(radio_type_t radioType) {
+    // Find the ICCID by radio type
+    esimProfiles(NULL, profiles, PROFILES_SIZE_MAX);
+
+    char specifiedIccid[ICCID_LEN + 1] = {0};
+    if (findIccidByType(profiles, strlen(profiles), specifiedIccid, radioType) != 0) {
+        Log.error("Could not find requested radio_type!");
+        return -1;
+    }
+
+    if (enableDisableProfile(ICCID_ENABLE, specifiedIccid, radioType) == ENABLE_DISABLE_SUCCESS) {
+        cachedRadioType_ = radioType;
+    }
+
+    return 0;
+}
+
+int ModemManager::waitAtResponse(unsigned int tries, unsigned int timeout) {
+    unsigned int attempt = 0;
+    for (;;) {
+        const int r = Cellular.command(timeout, "AT\r\n");
+        if (r < 0 && r != SYSTEM_ERROR_TIMEOUT) {
+            return r;
+        }
+        if (r == RESP_OK) {
+            return SYSTEM_ERROR_NONE;
+        }
+        if (++attempt >= tries) {
+            break;
+        }
+    }
+    return SYSTEM_ERROR_TIMEOUT;
+}
+
+int ModemManager::begin() {
+    begun_ = true;
+
+    if (!Cellular.isOn() || Cellular.isOff()) {
+        // Turn on the modem
+        Cellular.on();
+        if (!waitFor(Cellular.isOn, 60000)) {
+            return SYSTEM_ERROR_TIMEOUT;
+        }
+    }
+
+    waitAtResponse(5); // Check if the module is alive
+
+    Cellular.command(2000, "AT+QGMR\r\n");
+
+    return 0;
+}
+
+} // namespace particle
+
+

--- a/lib/satellite/src/modem_manager.h
+++ b/lib/satellite/src/modem_manager.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2024 Particle Industries, Inc.  All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "Particle.h"
+
+#include "system_error.h"
+
+namespace particle {
+
+typedef enum {
+    RADIO_UNKNOWN                    = 1,
+    RADIO_CELLULAR                   = 2,
+    RADIO_SATELLITE                  = 3,
+} radio_type_t;
+
+#define ICCID_LEN               (20)
+
+typedef enum {
+    ENABLE_DISABLE_SUCCESS                         = 0,
+    ENABLE_DISABLE_ICCID_IS_DEFAULT                = 1,
+    ENABLE_DISABLE_ICCID_DOES_NOT_EXIST            = 2,
+    ENABLE_DISABLE_ICCID_NOT_ACTIVE                = 3,
+    ENABLE_DISABLE_ICCID_IS_ACTIVE                 = 4,
+} enable_disable_error_t;
+
+class ModemManager {
+
+public:
+
+    ModemManager();
+    ~ModemManager();
+
+    int begin(void);
+    int esimEnable(char* specifiedIccid);
+    int esimDisable(char* specifiedIccid);
+    int esimProfiles(char* specifiedIccid, char* profilesBuffer, int profilesBufferLen);
+    radio_type_t radioEnabled();
+    int radioEnable(radio_type_t radio_type);
+
+private:
+
+    bool begun_; // true if begin() previously called
+    radio_type_t cachedRadioType_;
+
+    static int cbCFUN(int type, const char* buf, int len, int* cfun);
+    static int cbIOTOPMODE(int type, const char* buf, int len, int* mode);
+    static int cbCSIMint(int type, const char* buf, int len, int* csimInt);
+    static int cbCSIMstring(int type, const char* buf, int len, char* csimString);
+    static int cbICCID(int type, const char* buf, int len, char* iccid);
+
+    int waitAtResponse(unsigned int tries, unsigned int timeout = 3000);
+
+    void swapNibbles(const char* input, char* output);
+    int isValidHexString(const char *str, int length);
+    void stripTrailingF(char* iccid);
+    int findIccids(const char *input, char results[][ICCID_LEN + 1], bool includeTestProfile);
+    int getICCID(char* i, bool log);
+    void enableDisableICCID(int type, char* specifiedIccid, int radioType);
+    int enableDisableProfile(int type, char* specifiedIccid, int radioType);
+    int findIccidByType(const char* inputBuffer, int inputBufferLen, char* matchedIccid, int radioType);
+    void updateCachedRadioType(char* iccid);
+
+};
+
+} // particle

--- a/lib/satellite/src/satellite.h
+++ b/lib/satellite/src/satellite.h
@@ -24,13 +24,13 @@
 
 #include <optional>
 
-const auto NW_CONNECTED_INIT = 0;
-const auto NW_CONNECTED_SUCCESS = 1;
-const auto NW_CONNECTED_FAILED = 2;
+const uint8_t NW_CONNECTED_INIT = 0;
+const uint8_t NW_CONNECTED_SUCCESS = 1;
+const uint8_t NW_CONNECTED_FAILED = 2;
 
-const auto NW_STATE_IDLE = 0;
-const auto NW_STATE_CONNECT = 1;
-const auto NW_STATE_DISCONNECT = 2;
+const uint8_t NW_STATE_IDLE = 0;
+const uint8_t NW_STATE_CONNECT = 1;
+const uint8_t NW_STATE_DISCONNECT = 2;
 
 namespace particle {
 
@@ -98,10 +98,10 @@ private:
 
     bool begun_; // true if begin() previously called
 
-    bool registered_ = false;
-    uint8_t ntnConnected = 0;
-    uint8_t nwConnected = NW_CONNECTED_INIT;
-    uint8_t nwConnectionDesired = NW_STATE_IDLE;
+    uint8_t registered_ = 0;
+    volatile uint8_t ntnConnected = 0;
+    volatile uint8_t nwConnected = NW_CONNECTED_INIT;
+    volatile uint8_t nwConnectionDesired = NW_STATE_IDLE;
     uint32_t lastReceivedCheck_ = 0;
     uint32_t lastRegistrationCheck_ = 0;
     uint32_t registrationUpdateMs_ = 0;

--- a/lib/satellite/src/satellite.h
+++ b/lib/satellite/src/satellite.h
@@ -28,6 +28,10 @@ const auto NW_CONNECTED_INIT = 0;
 const auto NW_CONNECTED_SUCCESS = 1;
 const auto NW_CONNECTED_FAILED = 2;
 
+const auto NW_STATE_IDLE = 0;
+const auto NW_STATE_CONNECT = 1;
+const auto NW_STATE_DISCONNECT = 2;
+
 namespace particle {
 
 struct GnssPositioningInfo {
@@ -95,16 +99,20 @@ private:
     bool begun_; // true if begin() previously called
 
     bool registered_ = false;
+    uint8_t ntnConnected = 0;
     uint8_t nwConnected = NW_CONNECTED_INIT;
+    uint8_t nwConnectionDesired = NW_STATE_IDLE;
     uint32_t lastReceivedCheck_ = 0;
     uint32_t lastRegistrationCheck_ = 0;
     uint32_t registrationUpdateMs_ = 0;
+    uint32_t noRegistrationTimer_ = 0;
     int errorCount_ = 0;
     GnssPositioningInfo lastPositionInfo_;
     constrained::CloudProtocol proto_;
 
     char publishBuffer[1024] = {};
 
+    static int cbCFUN(int type, const char* buf, int len, int* cfun);
     static int cbICCID(int type, const char* buf, int len, char* iccid);
     static int cbCOPS(int type, const char* buf, int len, char* network);
     static int cbQCFGEXTquery(int type, const char* buf, int len, int* rxlen);
@@ -118,6 +126,8 @@ private:
 
     void receiveData(void);
     int processErrors(void);
+    int connectImpl(void);
+    int getICCID(char* i, bool log);
 };
 
 } // particle

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -17,61 +17,86 @@
 
 #include "Particle.h"
 #include "satellite.h"
+#include "modem_manager.h"
 
 SYSTEM_MODE(SEMI_AUTOMATIC);
 
 SerialLogHandler logHandler(LOG_LEVEL_ALL);
 
 Satellite satellite;
+ModemManager modem;
 
-typedef enum AppState {
+// NOTE: Set both of the following options to 0 for normal operation, or 1 to TEST forced switching between radios
+//       based on the timeouts that follow.  e.g. if FORCE_CELLULAR_TO_SATELLITE_SWITCH is set to 1 and
+//       FORCE_RADIO_CELLULAR_TO_SATELLITE_SWITCH_TIMEOUT is set to 120000, the application will switch from Cellular
+//       to Satellite after 2 minutes.
+#define FORCE_CELLULAR_TO_SATELLITE_SWITCH (1)
+#define FORCE_SATELLITE_TO_CELLULAR_SWITCH (1)
+#define FORCE_RADIO_CELLULAR_TO_SATELLITE_SWITCH_TIMEOUT (2 * 60 * 1000)
+#define FORCE_RADIO_SATELLITE_TO_CELLULAR_SWITCH_TIMEOUT (2 * 60 * 1000)
+
+// These are pretty standard timeouts.  It is NOT recommended to set them below 10 minutes.
+// There is no CELLULAR_CONNECTED_TIMEOUT because if it's connected there's no reason to switch to satellite.
+#define CELLULAR_DISCONNECTED_TIMEOUT (10 * 60 * 1000)
+#define SATELLITE_CONNECTED_TIMEOUT (10 * 60 * 1000)
+#define SATELLITE_DISCONNECTED_TIMEOUT (20 * 60 * 1000)
+
+// NOT recommended to set the publish interval below 10 seconds when on satellite
+#define PUBLISH_INTERVAL (30000)
+
+// Start up on Cellular (1) Start up on Satellite (0)
+// NOTE: This is just for testing, you should always start on Cellular and only switch
+// to Satellite if cellular signal drops.
+#define START_ON_CELLULAR (1)
+
+typedef enum AppPublishState {
+    WaitForConnnect,
     GetGNSSLocation,
     PublishGNSSLocation
-} AppState;
+} AppPublishState;
 
-uint32_t s = 0;
+uint32_t lastPublish = 0;
+uint32_t connectedTime = 0;
+uint32_t disconnectedTime = 0;
+uint32_t radioTime = 0;
+
 int publishCount = 1;
 int satPublishSuccess = 0;
 int satPublishFailures = 0;
-AppState state = AppState::GetGNSSLocation;
+AppPublishState publishState = AppPublishState::WaitForConnnect;
 
-void setup()
-{
-    //waitUntil(Serial.isConnected);
 
-    pinMode(D7, OUTPUT);
-    digitalWrite(D7, LOW);
-    RGB.control(true);
-    RGB.color(0,255,0);
+void updateConnectionTimers() {
+    bool connected = false;
+    static radio_type_t lastRadio = RADIO_UNKNOWN;
 
-    // WiFi.setCredentials("MySSID", "MyPassword");
-    if (WiFi.hasCredentials()) {
-        WiFi.on();
-        waitUntil(WiFi.isOn);
-        WiFi.connect();
-        if (waitFor(WiFi.ready, 30000)) {
-            Particle.connect();
+    if (modem.radioEnabled() == RADIO_CELLULAR) {
+        if (Particle.connected()) {
+            connected = true;
+        }
+    } else if (modem.radioEnabled() == RADIO_SATELLITE) {
+        if (satellite.connected()) {
+            connected = true;
         }
     }
 
-    Log.info("BEGIN --------------------");
-    if (satellite.begin() == SYSTEM_ERROR_NONE) {
-        satellite.process();
+    if (lastRadio != modem.radioEnabled()) {
+        connectedTime = 0;
+        disconnectedTime = 0;
+        radioTime = millis(); // reset radio time
+        lastRadio = modem.radioEnabled();
+    }
 
-        Log.info("CONNECT ---------------------");
-        satellite.connect();
-        waitUntil(satellite.connected);
-        satellite.process();
-
-        if (satellite.connected()) {
-            RGB.color(0,255,255);
-            Log.info("SATELLITE CONNECTED ------------------");
-            digitalWrite(D7, HIGH);
-            s = millis() - 30000;
+    if (connected) {
+        if (!connectedTime) {
+            connectedTime = millis();
         }
+        disconnectedTime = 0;
     } else {
-        Log.error("Error initializing Satellite radio");
-        RGB.color(255,0,0);
+        if (!disconnectedTime) {
+            disconnectedTime = millis();
+        }
+        connectedTime = 0;
     }
 }
 
@@ -101,54 +126,181 @@ int publishLocation(GnssPositioningInfo position) {
     return Particle.publish("loc", publishBuffer);
 }
 
+void setup()
+{
+    // waitUntil(Serial.isConnected);
+    WiFi.clearCredentials(); // force testing on Cellular/Satellite
+
+    pinMode(D7, OUTPUT);
+    digitalWrite(D7, LOW);
+
+    // Make sure we start up with Cellular enabled,
+    // it is less expensive and can handle larger payloads.
+    Log.info("RADIO CELLULAR --------------------");
+    modem.begin();
+
+#if START_ON_CELLULAR
+    // Start on Cellular
+    modem.radioEnable(RADIO_CELLULAR);
+
+    Particle.connect();
+    waitFor(Particle.connected, 120000);
+
+#else
+    // Start on Satellite
+    modem.radioEnable(RADIO_SATELLITE);
+    RGB.control(true);
+    RGB.color(0,255,0);
+
+    if (satellite.begin() == SYSTEM_ERROR_NONE) {
+        satellite.process();
+
+        satellite.connect();
+    } else {
+        Log.error("Error initializing Satellite radio");
+        RGB.color(255,0,0);
+    }
+#endif // START_ON_CELLULAR
+}
+
 void loop()
 {
-    if (satellite.connected() && millis() - s > 30000) {
-        s = millis();
+    updateConnectionTimers();
 
-        switch(state) {
-            case AppState::GetGNSSLocation:
+    // If on Cellular connection, if no signal for 10 minutes, switch to Satellite
+    if ( (modem.radioEnabled() == RADIO_CELLULAR) &&
+
+#if FORCE_CELLULAR_TO_SATELLITE_SWITCH
+            (radioTime && (millis() - radioTime > FORCE_RADIO_CELLULAR_TO_SATELLITE_SWITCH_TIMEOUT))
+#else
+            (disconnectedTime && (millis() - disconnectedTime > CELLULAR_DISCONNECTED_TIMEOUT))
+#endif // FORCE_RADIO_CELLULAR_TO_SATELLITE_SWITCH_TIMEOUT
+            )
+    {
+        Log.info("SWITCH to SATELLITE --------------------");
+        // NOTE: Very important to disconnect both Cloud and Cellular before switching to Satellite
+        Particle.disconnect();
+        waitFor(Particle.disconnected, 60000);
+        Cellular.disconnect();
+
+        Log.info("RADIO SATELLITE --------------------");
+        if (modem.radioEnable(RADIO_SATELLITE) == SYSTEM_ERROR_NONE) {
+            RGB.control(true);
+            RGB.color(0,255,0);
+
+            Log.info("SATELLITE BEGIN --------------------");
+            if (satellite.begin() == SYSTEM_ERROR_NONE) {
+                satellite.process();
+
+                Log.info("SATELLITE CONNECT ---------------------");
+                satellite.connect();
+            } else {
+                Log.error("Error initializing Satellite radio");
+                RGB.color(255,0,0);
+            }
+        }
+        publishState = AppPublishState::WaitForConnnect;
+    }
+    // If on Satellite connection, if connected or disconnected for 10 minutes, switch to Cellular
+    //
+    // Note: we don't want to camp on Satellite if Cellular is available, but
+    //       the only way to know if Cellular is available is to go test it again.
+    else if ( (modem.radioEnabled() == RADIO_SATELLITE) &&
+
+#if FORCE_SATELLITE_TO_CELLULAR_SWITCH
+            (radioTime && (millis() - radioTime > FORCE_RADIO_SATELLITE_TO_CELLULAR_SWITCH_TIMEOUT))
+#else
+            ( (disconnectedTime && (millis() - disconnectedTime > SATELLITE_DISCONNECTED_TIMEOUT)) || (connectedTime && (millis() - connectedTime > SATELLITE_CONNECTED_TIMEOUT)) )
+#endif // FORCE_RADIO_SATELLITE_TO_CELLULAR_SWITCH_TIMEOUT
+            )
+    {
+        Log.info("SWITCH to CELLULAR --------------------");
+        // NOTE: Very important to disconnect Satellite before switching to Cellular
+        satellite.disconnect();
+        satellite.process(); // process disconnect
+        RGB.control(false);
+
+        Log.info("RADIO CELLULAR --------------------");
+        if (modem.radioEnable(RADIO_CELLULAR) == SYSTEM_ERROR_NONE) {
+
+            Log.info("CELLULAR CONNECT ---------------------");
+            Particle.connect();
+            waitFor(Particle.connected, 120000);
+        }
+        publishState = AppPublishState::WaitForConnnect;
+    }
+
+    // Attempt to publish
+    if (millis() - lastPublish > PUBLISH_INTERVAL) {
+        // Handle publish differently based on connection type, also publish location
+        switch (publishState) {
+            case AppPublishState::WaitForConnnect:
             {
-                satellite.getGNSSLocation();
-                // Make sure we re-connect to Skylo NTN after getting gnss fix
-                satellite.process(true /* force updateRegistration */);
-
-                state = AppState::PublishGNSSLocation;
+                if (satellite.connected() || Particle.connected()) {
+                    publishState = AppPublishState::GetGNSSLocation;
+                }
                 break;
             }
 
-            case AppState::PublishGNSSLocation:
+            case AppPublishState::GetGNSSLocation:
             {
-                Log.info("PUBLISH: satellite/1 {\"count\",%d} ------------------", publishCount);
+                satellite.getGNSSLocation();
+                if (modem.radioEnabled() == RADIO_SATELLITE) {
+                    // Make sure we re-connect to Skylo NTN after getting gnss fix
+                    satellite.process(true /* force updateRegistration */);
+                }
+                lastPublish = millis() - PUBLISH_INTERVAL + 2000; // Ensure we don't try to publish immediately after using GNSS
+                publishState = AppPublishState::PublishGNSSLocation;
+                break;
+            }
 
+            case AppPublishState::PublishGNSSLocation:
+            {
                 Variant data;
                 data.set("count", publishCount);
                 data.set("lat", satellite.lastPositionInfo().latitude);
                 data.set("long", satellite.lastPositionInfo().longitude);
                 //data.set("alt", (int)satellite.lastPositionInfo().altitude);
 
-                if (satellite.connected()) {
+                if (satellite.connected())
+                {
+                    Log.info("SATELLITE PUBLISH: {\"count\",%d} ------------------", publishCount);
                     auto satPublishResult = satellite.publish(1 /* code */, data);
                     satPublishResult < 0 ? satPublishFailures++ : satPublishSuccess++;
-                    Log.info("Satellite publish successes/total %d/%d ", satPublishSuccess, publishCount);
+                    Log.info("Satellite publish successes/total %d/%d ", satPublishSuccess, satPublishSuccess + satPublishFailures);
+                    lastPublish = millis();
                 }
+                else if (Particle.connected())
+                {
+                    Log.info("CELLULAR PUBLISH: {\"count\",%d} ------------------", publishCount);
+                    Particle.publish("cellular", String::format("{\"count\",%d}", publishCount));
 
-                if (Particle.connected()) {
                     auto cloudPublishResult = publishLocation(satellite.lastPositionInfo());
-                    Log.info("Cloud publish result: %d", cloudPublishResult);
+                    Log.info("Cellular publish result: %d", cloudPublishResult);
+                    lastPublish = millis();
+                } else {
+                    publishState = AppPublishState::WaitForConnnect;
+                    break;
                 }
 
                 publishCount++;
-                state = AppState::GetGNSSLocation;
+                publishState = AppPublishState::GetGNSSLocation;
                 break;
             }
 
             default:
                 break;
         }
+
     }
 
-    satellite.process();
+    if (modem.radioEnabled() == RADIO_SATELLITE) {
+        satellite.process();
+
+        if (satellite.connected()) {
+            RGB.color(0,255,255);
+        }
+    }
 }
 
 

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -37,9 +37,10 @@ ModemManager modem;
 
 // These are pretty standard timeouts.  It is NOT recommended to set them below 10 minutes.
 // There is no CELLULAR_CONNECTED_TIMEOUT because if it's connected there's no reason to switch to satellite.
+// Satellite can take a long time to initially connect so it's not recommended to set the DISCONN. timeout too low.
 #define CELLULAR_DISCONNECTED_TIMEOUT (10 * 60 * 1000)
 #define SATELLITE_CONNECTED_TIMEOUT (10 * 60 * 1000)
-#define SATELLITE_DISCONNECTED_TIMEOUT (60 * 60 * 1000)
+#define SATELLITE_DISCONNECTED_TIMEOUT (20 * 60 * 1000)
 
 // NOT recommended to set the publish interval below 10 seconds when on satellite
 #define PUBLISH_INTERVAL (30000)


### PR DESCRIPTION
# Feature

- Adds eSIM management allowing switching between LTE Cellular and NTN Satellite communications
- Test application has a few customizable options, allowing forced switching between radios at custom time intervals.  However, normal operation should typically favor Cellular as long as it's available, only switching to Satellite when Cellular goes down for a period of time.
- See `app.cpp` notes for all available options.  Here's how to set up for TEST mode which will switch between Cellular and Satellite every 2 minutes regardless of connection status.  App will also attempt to acquire GPS location information and publish it over Cellular and Satellite connections.  Make sure all of your antennas point skyward and are outdoors for the best chance of connecting.  Normally though, app is set for NORMAL mode and will only switch to satellite if cellular drops.
```
#define FORCE_CELLULAR_TO_SATELLITE_SWITCH (1)
#define FORCE_SATELLITE_TO_CELLULAR_SWITCH (1)
#define FORCE_RADIO_CELLULAR_TO_SATELLITE_SWITCH_TIMEOUT (2 * 60 * 1000)
#define FORCE_RADIO_SATELLITE_TO_CELLULAR_SWITCH_TIMEOUT (2 * 60 * 1000)
```