### PR TITLE
Cloud first

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ All runtime behaviour is defined in a single top-level `env.json` file. Workbenc
 
 | Key | Type | Default | Meaning |
 |---|---|---|---|
+| `INITIAL_ONLINE_TIMEOUT_S` | uint | `0` | If `> 0`, connect to the Particle cloud once at boot. Stays online for this many seconds, then disconnect and proceed to the normal startup flow. Useful to ensure the cloud can update device state and environment variables. Recommended: 60 seconds on first setup, and can be set to 0 when doing NTN tests.
 | `FEATURE_LTE_ENABLED` | bool | `false` | Allow LTE-M as a connectivity stack. |
 | `FEATURE_NTN_ENABLED` | bool | `true` | Allow Satellite NTN as a connectivity stack. At least one of the two `FEATURE_*_ENABLED` flags must be true; LTE will be enabled if both are false. |
 | `START_ON_CELLULAR` | bool | `false` | Which radio the device boots on. `true` = LTE-M; `false` = NTN (useful for NTN-first demos). |
@@ -98,10 +99,12 @@ Use the **fake LTE loss** option to exercise the hybrid fallback lifecycle witho
 
 ### Connectivity Lifecycle
 
+If `INITIAL_ONLINE_TIMEOUT_S > 0`, the device runs `InitialConnect` → `InitialOnline` first before moving to `Start`.
+
 ```
-                              ┌──────┐
-                              │ Boot │
-                              └──┬───┘
+                              ┌───────┐
+                              │ Start │
+                              └──┬────┘
                                  │ radioEnable(start radio)
                                  ▼
                        ┌──────────────────┐
@@ -127,7 +130,7 @@ Use the **fake LTE loss** option to exercise the hybrid fallback lifecycle witho
         radioEnable OK              radioEnable OK
         → SatelliteConnect          → CellularConnect
 
-   (any radioEnable / satellite.begin() failure → Fault → Boot)
+   (any radioEnable / satellite.begin() failure → Fault → Start)
 ```
 
 **LTE failure definition:** LTE is considered unavailable when no successful LTE publish occurs within the configured timeout window — even if registration, attach, or partial connectivity succeeds.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ All runtime behaviour is defined in a single top-level `env.json` file. Workbenc
 
 | Key | Type | Default | Meaning |
 |---|---|---|---|
-| `INITIAL_ONLINE_TIMEOUT_S` | uint | `0` | If `> 0`, connect to the Particle cloud once at boot. Stays online for this many seconds, then disconnect and proceed to the normal startup flow. Useful to ensure the cloud can update device state and environment variables. Recommended: 60 seconds on first setup, and can be set to 0 when doing NTN tests.
+| `INITIAL_ONLINE_TIMEOUT_S` | uint | `0` | If `> 0`, connect to the Particle cloud once at boot. Stays online for this many seconds, then disconnect and proceed to the normal startup flow. Useful to ensure the cloud can update device state and environment variables. Can be 0 when if setting PARTICLE_LOCATION_FIXED directly, or when using setup.particle.io.
 | `FEATURE_LTE_ENABLED` | bool | `false` | Allow LTE-M as a connectivity stack. |
 | `FEATURE_NTN_ENABLED` | bool | `true` | Allow Satellite NTN as a connectivity stack. At least one of the two `FEATURE_*_ENABLED` flags must be true; LTE will be enabled if both are false. |
 | `START_ON_CELLULAR` | bool | `false` | Which radio the device boots on. `true` = LTE-M; `false` = NTN (useful for NTN-first demos). |

--- a/env.json
+++ b/env.json
@@ -1,4 +1,6 @@
 {
+  "INITIAL_ONLINE_TIMEOUT_S": "0",
+
   "FEATURE_LTE_ENABLED": "false",
   "FEATURE_NTN_ENABLED": "true",
 

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -35,7 +35,9 @@ AppPublisher publisher(satellite, modem);
 // Application state machine
 // -----------------------------------------------------------------------------
 enum class AppState {
-    Boot,              // init: enable the start radio, reset timers
+    InitialConnect,    // optional initial connection to the Particle cloud
+    InitialOnline,     // hold the initial cloud connection, then disconnect
+    Start,             // init: enable the start radio, reset timers
     AcquireLocation,   // get a GNSS fix (or fixed fallback) and set ntn_locfix
     CellularConnect,   // Particle.connect() issued; waiting for the cloud
     CellularOnline,    // connected on LTE; publishing on the LTE interval
@@ -47,7 +49,7 @@ enum class AppState {
     Fault              // error / recovery (modem-reset escalation hook)
 };
 
-static AppState appState = AppState::Boot;
+static AppState appState = AppState::Start;
 static bool stateEntry = true;   // true on the first loop() after a transition
 uint32_t stateEnterTime = 0;     // millis() when the current state was entered
 
@@ -65,7 +67,9 @@ bool havePubLoc = false;
 
 const char* stateName(AppState s) {
     switch (s) {
-        case AppState::Boot:              return "Boot";
+        case AppState::InitialConnect:    return "InitialConnect";
+        case AppState::InitialOnline:     return "InitialOnline";
+        case AppState::Start:             return "Start";
         case AppState::CellularConnect:   return "CellularConnect";
         case AppState::CellularOnline:    return "CellularOnline";
         case AppState::AcquireLocation:   return "AcquireLocation";
@@ -439,8 +443,9 @@ void setup()
 
     modem.begin();
 
-    // Hardware is initialised; the Boot state selects and enables the start radio.
-    appState = AppState::Boot;
+    // Hardware is initialised. Perform the initial connection if configured, or
+    // start the state machine directly.
+    appState = (g_cfg.initialOnlineTimeoutS > 0) ? AppState::InitialConnect : AppState::Start;
     stateEntry = true;
     stateEnterTime = millis();
 }
@@ -452,7 +457,39 @@ void loop()
 
     switch (appState) {
         // --------------------------------------------------------------------
-        case AppState::Boot:
+        case AppState::InitialConnect:
+        {
+            if (onEntry()) {
+                Log.info("INITIAL CONNECT --------------------");
+                modem.radioEnable(RADIO_CELLULAR);
+                Particle.connect();
+            }
+            if (Particle.connected()) {
+            	Log.info("Connected to the cloud");
+                transitionTo(AppState::InitialOnline);
+            }
+            break;
+        }
+
+        // --------------------------------------------------------------------
+        case AppState::InitialOnline:
+        {
+            if (!Particle.connected()) {
+                Log.warn("Lost cloud connection early");
+                transitionTo(AppState::Start);
+                break;
+            }
+            if (millis() - stateEnterTime >= g_cfg.initialOnlineTimeoutS * 1000UL) {
+                Log.warn("Disconnecting initial cloud connection");
+                Particle.disconnect();
+                waitFor(Particle.disconnected, 60000);
+                transitionTo(AppState::Start);
+            }
+            break;
+        }
+
+        // --------------------------------------------------------------------
+        case AppState::Start:
         {
             if (g_cfg.startOnCellular && g_cfg.lteEnabled) {
                 Log.info("RADIO CELLULAR --------------------");
@@ -635,12 +672,12 @@ void loop()
         case AppState::Fault:
         {
             // Placeholder for recovery / modem-reset escalation (future work).
-            // For now, surface the fault and re-initialise from Boot.
+            // For now, surface the fault and re-initialise from Start.
             Log.error("FAULT state - re-initialising");
             RGB.control(true);
             RGB.color(255,0,0);
             delay(5000);
-            transitionTo(AppState::Boot);
+            transitionTo(AppState::Start);
             break;
         }
 

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -483,6 +483,7 @@ void loop()
                 Log.warn("Disconnecting initial cloud connection");
                 Particle.disconnect();
                 waitFor(Particle.disconnected, 60000);
+                Cellular.disconnect();
                 transitionTo(AppState::Start);
             }
             break;

--- a/src/app_config.cpp
+++ b/src/app_config.cpp
@@ -86,6 +86,7 @@ bool applyFixedLocationEnv() {
 AppConfig g_cfg = {
     /* lteEnabled                     */ false,
     /* ntnEnabled                     */ true,
+    /* initialOnlineTimeoutS          */ 0,
     /* startOnCellular                */ false,
     /* ltePublishIntervalS            */ 60,
     /* ntnPublishIntervalS            */ 3 * 60,
@@ -110,6 +111,7 @@ void loadAppConfig() {
     // Source every setting from its environment variable (env.json). Each helper
     // leaves the compiled default in place when the variable is absent or
     // invalid, so the device always boots with a usable configuration.
+    applyU32Env      ("INITIAL_ONLINE_TIMEOUT_S",           g_cfg.initialOnlineTimeoutS);
     applyBoolEnv     ("FEATURE_LTE_ENABLED",                g_cfg.lteEnabled);
     applyBoolEnv     ("FEATURE_NTN_ENABLED",                g_cfg.ntnEnabled);
     applyBoolEnv     ("START_ON_CELLULAR",                  g_cfg.startOnCellular);
@@ -154,10 +156,11 @@ void loadAppConfig() {
     }
 
     cfgLog.info("App config:");
-    cfgLog.info("  lteEnabled=%s ntnEnabled=%s startOnCellular=%s",
+    cfgLog.info("  lteEnabled=%s ntnEnabled=%s startOnCellular=%s initialOnlineTimeoutS=%lus",
         g_cfg.lteEnabled ? "true" : "false",
         g_cfg.ntnEnabled ? "true" : "false",
-        g_cfg.startOnCellular ? "true" : "false");
+        g_cfg.startOnCellular ? "true" : "false",
+        (unsigned long)g_cfg.initialOnlineTimeoutS);
     cfgLog.info("  publish: lte=%lus ntn=%lus vitals=%lus ntnMaxBytes=%lu",
         (unsigned long)g_cfg.ltePublishIntervalS,
         (unsigned long)g_cfg.ntnPublishIntervalS,

--- a/src/app_config.h
+++ b/src/app_config.h
@@ -43,6 +43,10 @@ struct AppConfig {
     bool ntnEnabled;
 
     // ---- Startup ----------------------------------------------------------
+    // If > 0, connect to the Particle cloud once at boot to give the opportunity
+    // for the cloud to update the device state and update environment variables.
+    uint32_t initialOnlineTimeoutS;
+
     // true  = boot on Cellular (LTE-M)
     // false = boot on Satellite (NTN). Useful for NTN-first demos.
     bool startOnCellular;


### PR DESCRIPTION
Connect to the cloud once on initialization (if configured) to ensure the cloud can update environment variables, OTA, etc. It will also ensure that the cloud gets one good describe message so the Console doesn't look empty for a new M635 device used for NTN testing.

TODO
- [x] Rebase to main once #8 is merged