### PR TITLE
Make serial wait configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ All runtime behaviour is defined in a single top-level `env.json` file. Workbenc
 
 | Key | Type | Default | Meaning |
 |---|---|---|---|
+| `SERIAL_WAIT_TIMEOUT_S` | uint | `10` | Seconds to wait at boot for a USB host to open the serial port before continuing, so a serial monitor attached in time can see early boot logs. |
 | `INITIAL_ONLINE_TIMEOUT_S` | uint | `0` | If `> 0`, connect to the Particle cloud once at boot. Stays online for this many seconds, then disconnect and proceed to the normal startup flow. Useful to ensure the cloud can update device state and environment variables. Can be 0 when if setting PARTICLE_LOCATION_FIXED directly, or when using setup.particle.io.
 | `FEATURE_LTE_ENABLED` | bool | `false` | Allow LTE-M as a connectivity stack. |
 | `FEATURE_NTN_ENABLED` | bool | `true` | Allow Satellite NTN as a connectivity stack. At least one of the two `FEATURE_*_ENABLED` flags must be true; LTE will be enabled if both are false. |

--- a/env.json
+++ b/env.json
@@ -1,4 +1,5 @@
 {
+  "SERIAL_WAIT_TIMEOUT_S": "10",
   "INITIAL_ONLINE_TIMEOUT_S": "0",
 
   "FEATURE_LTE_ENABLED": "false",

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -443,7 +443,9 @@ void ctrl_request_custom_handler(ctrl_request* req) {
 
 void setup()
 {
-    waitFor(Serial.isConnected, 10000);
+    int serialWaitTimeoutS = 10;
+    System.getEnv("SERIAL_WAIT_TIMEOUT_S", serialWaitTimeoutS);
+    waitFor(Serial.isConnected, serialWaitTimeoutS * 1000);
     // WiFi.clearCredentials(); // force testing on Cellular/Satellite
 
     pinMode(D7, OUTPUT);


### PR DESCRIPTION
When running the application in setup, it's preferable to start connecting right away rather than wait for 10 seconds for serial to connect.